### PR TITLE
fix Undefined variable $relationName (View: langTabAll.blade.php)

### DIFF
--- a/src/Extensions/LangTabAll.php
+++ b/src/Extensions/LangTabAll.php
@@ -443,12 +443,14 @@ EOT;
 
         $this->setupScript($script);
 
-        return parent::render()->with([
+        $this->addVariables([
             'forms'        => $this->buildRelatedForms(),
             'template'     => $template,
             'template_fields' => $template_fields,
             'relationName' => $this->relationName,
             'options'      => $this->options,
         ]);
+
+        return parent::render();
     }
 }


### PR DESCRIPTION
Greetings

Fixed an error when using $form->langtaball().

Error text:
  Undefined variable $relationName (View: /var/www/vendor/nitro-lab/multilanguage-admin/src/views/langTabAll.blade.php) (View: /var/www/vendor/nitro-lab/multilanguage-admin/src/views/langTabAll.blade.php)

In the previous version, the form was first rendered, and then variables were added to it, and this caused an error. That is, it was rendered without variables.

Environment:
php 8.1, encore/laravel-admin 1.8

Please, if possible, consider merging this pull request in the near future, so as not to cheat in the project)